### PR TITLE
DEVOPS-664 :: Disable "no-else-return" warning in valifn project

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -98,6 +98,7 @@ disable=raw-checker-failed,
         attribute-defined-outside-init,
         signature-differs,
         #imported-auth-user,
+        no-else-return  # an else-return is more readable
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Warning "`no-else-return`" added to `tool.pylint."messages control". Disable` list of disabled rules.

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-python/pull/38/commits/23249a302a4714a4cffb344953f7b5edb585d76d"><code>23249a3</code></a> Warning "R1705: (no-else-return)" disabled
</li>
</ul>
</details>

<hr>

_More details about this issue at [DEVOPS-664 — Jira](https://valispace.atlassian.net/browse/DEVOPS-664)_
