### PR TITLE
VALI-5012 :: Use the same 'pint' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-# Valispace packages
-valispace==0.1.16   # Valispace API
+# Valispace packages (mandatory)
+valispace==0.1.16 # Valispace Python API
 
-# Basic scientifical packages
-pint==0.20.1        # Python library used for scientific
-scipy==1.9.3        # Python library to define, operate and manipulate physical quantities
+# Basic scientifical packages (mandatory)
+git+https://git@github.com/valispace/pint.git@0.21.dev0+valispace#egg=pint # Physical quantities module (Valispace version)
+scipy==1.9.3 # Fundamental algorithms for scientific computing in Python
 
-# Add other packages here
+# Add your packages here (optional)
 requests==2.28.2
 openpyxl==3.0.10
 xlrd==1.2.0


### PR DESCRIPTION
Project requirements changed to reference [Valispace Pint implementation](https://github.com/valispace/pint).

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-python/pull/42/commits/2afde49004a296a5f7d09acaa1c92bfc401b35ed"><code>2afde49</code></a> Use the same 'pint' dependency across the valispace
</li>
</ul>
</details>

<hr>

_More details about this issue at [VALI-5012 — Jira](https://valispace.atlassian.net/browse/VALI-5012)_
