### PR TITLE
DEVOPS-705 :: Add label 'version' to valifn-python Dockerfile

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.10-slim-buster
 
 LABEL org.opencontainers.image.description "Python docker image to be used by the Valispace Scripting Module"
 LABEL maintainer="Valispace DevOps <devops@valispace.com>"
+LABEL version="0.0.0"
 
 # Activate unattended package installation with default answers for all questions
 ENV DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Docker label `version` added to dockerfile and docker build command, thus allowing to quickly identify the `valifn-python` version running on the docker.

```bash
docker inspect IMAGE | jq '.[0].Config.Labels'
```

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-python/pull/56/commits/0865e44ed35305ba838e2b4aeeeef818109019ab"><code>0865e44</code></a> Docker label 'version' added to docker build command
</li>
</ul>
</details>

<hr>

_More details about this issue at [DEVOPS-705 — Jira](https://valispace.atlassian.net/browse/DEVOPS-705)_
