### PR TITLE
DEVOPS-836 bump valispace version to 0.1.24.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Valispace packages (mandatory)
-valispace==0.1.24 # Valispace Python API
+valispace==0.1.24.1 # Valispace Python API
 
 # Valispace integration Packages (optional)
 git+https://github.com/SimScaleGmbH/simscale-python-sdk.git@4.0.0 # SimScale Python SDK


### PR DESCRIPTION
Bumps version of valispace python api to 0.1.24.1


